### PR TITLE
Delete ZH~dd44.ffs_tmp:Zone.Identifier:$DATA

### DIFF
--- a/PCBs/Airrohr-PCB/Airrohr-PCB-V1.4/Connector_JST_ZH_3d/ZH~dd44.ffs_tmp:Zone.Identifier:$DATA
+++ b/PCBs/Airrohr-PCB/Airrohr-PCB-V1.4/Connector_JST_ZH_3d/ZH~dd44.ffs_tmp:Zone.Identifier:$DATA
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=http://www.jst-mfg.com/product/pdf/eng/eZH.pdf?5d0e7a052d5b6
-HostUrl=http://www.jst-mfg.com/product/pdf/eng/eZH.pdf?5d0e7a052d5b6


### PR DESCRIPTION
Please delete this file / prevent upload of this file, since cloning with Windows aborts because of illegal file name:
Cloning into 'C:\Users\[CUT]\Documents\GitHub\DNMS'...
remote: Enumerating objects: 673, done.        
remote: Counting objects: 100% (673/673), done.        
remote: Compressing objects: 100% (384/384), done.        
remote: Total 1552 (delta 371), reused 491 (delta 283), pack-reused 879        
Receiving objects: 100% (1552/1552), 49.37 MiB | 19.19 MiB/s, done.
Resolving deltas: 100% (774/774), done.
error: invalid path 'PCBs/Airrohr-PCB/Airrohr-PCB-V1.4/Connector_JST_ZH_3d/ZH~dd44.ffs_tmp:Zone.Identifier:$DATA'
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'

Would you like to retry cloning ?