### PR TITLE
Add platformio confguration, hex file script

### DIFF
--- a/Firmware/Teensy4.0/DNMS_V2.0.5/DNMS_V2.0.5.ino
+++ b/Firmware/Teensy4.0/DNMS_V2.0.5/DNMS_V2.0.5.ino
@@ -254,6 +254,37 @@ void loop() {
   }
 }
 
+  void f2b(float val, uint8_t* bytes_array) {
+    // Create union of shared memory space
+    union {
+      float float_variable;      //      leq_HP_min = 0;
+      //      leq_HP_max = 0;
+      uint8_t temp_array[4];
+    } u;
+    // Overite bytes of union with float variable
+    u.float_variable = val;
+    // Assign bytes to input array
+    memcpy(bytes_array, u.temp_array, 4);
+  }
+
+  uint8_t dnms_common_generate_crc(uint8_t *data, uint16_t count) {
+    uint16_t current_byte;
+    uint8_t crc = CRC8_INIT;
+    uint8_t crc_bit;
+
+    /* calculates 8-Bit checksum with given polynomial */
+    for (current_byte = 0; current_byte < count; ++current_byte) {
+      crc ^= (data[current_byte]);
+      for (crc_bit = 8; crc_bit > 0; --crc_bit) {
+        if (crc & 0x80)
+          crc = (crc << 1) ^ CRC8_POLYNOMIAL;
+        else
+          crc = (crc << 1);
+      }
+    }
+    return crc;
+  }
+
   void i2c_request_from_master() {
     uint16_t i;
     uint16_t idx;
@@ -368,33 +399,3 @@ void loop() {
   }
 
 
-  void f2b(float val, uint8_t* bytes_array) {
-    // Create union of shared memory space
-    union {
-      float float_variable;      //      leq_HP_min = 0;
-      //      leq_HP_max = 0;
-      uint8_t temp_array[4];
-    } u;
-    // Overite bytes of union with float variable
-    u.float_variable = val;
-    // Assign bytes to input array
-    memcpy(bytes_array, u.temp_array, 4);
-  }
-
-  uint8_t dnms_common_generate_crc(uint8_t *data, uint16_t count) {
-    uint16_t current_byte;
-    uint8_t crc = CRC8_INIT;
-    uint8_t crc_bit;
-
-    /* calculates 8-Bit checksum with given polynomial */
-    for (current_byte = 0; current_byte < count; ++current_byte) {
-      crc ^= (data[current_byte]);
-      for (crc_bit = 8; crc_bit > 0; --crc_bit) {
-        if (crc & 0x80)
-          crc = (crc << 1) ^ CRC8_POLYNOMIAL;
-        else
-          crc = (crc << 1);
-      }
-    }
-    return crc;
-  }

--- a/Firmware/Teensy4.0/DNMS_V2.0.5/platformio.ini
+++ b/Firmware/Teensy4.0/DNMS_V2.0.5/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+default_envs = DNMS_V2.0.5
+src_dir = .
+
+[env:DNMS_V2.0.5]
+platform = teensy
+board = teensy40
+framework = arduino
+lib_deps =
+  https://github.com/Richard-Gemmell/teensy4_i2c
+  ../../dnms_audio_lib-master.zip
+extra_scripts = ../build_script.py
+build_flags = -DUSB_AUDIO
+

--- a/Firmware/Teensy4.0/build_script.py
+++ b/Firmware/Teensy4.0/build_script.py
@@ -1,0 +1,10 @@
+Import("env")
+import shutil
+
+# copies the firmware.hex file to a file with a target-specific name
+def copy_firmware_hex(source, target, env):
+    hexfile_name = f'{env["PROJECT_DIR"]}/{env["PIOENV"]}.hex'
+    shutil.copy(target[0].path, hexfile_name)
+
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex", copy_firmware_hex)
+


### PR DESCRIPTION
This adds a platformio configuration file for the V2.0.5 firmware, plus a platformio build script to generate the HEX file.
I had to modify the .ino file slightly, just reorder some functions, no actual change.

You can try this out yourself, in the following way (from the command line):
* install python3 and pip3
* use pip3 to install platformio
sudo pip3 install platformio
* enter the DNMS_V2.0.5 directory
* run the platformio build
pio run

Platformio will do a one-time download of the toolchain, libraries, etc and cache them for future use.
This produces a DNMS_V2.0.5.hex file that you should be able to flash to the hardware.

Please try this out. If this works for you, we can add platformio configuration for the other software versions too.